### PR TITLE
Plugin modularity enhancements

### DIFF
--- a/src/Administration/Command/AdministrationDumpBundlesCommand.php
+++ b/src/Administration/Command/AdministrationDumpBundlesCommand.php
@@ -3,7 +3,6 @@
 namespace Shopware\Administration\Command;
 
 use Shopware\Core\Framework\Bundle;
-use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Kernel;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -46,13 +45,10 @@ class AdministrationDumpBundlesCommand extends Command
     {
         $bundles = [];
 
-        foreach ($this->kernel->getBundles() as $bundle) {
+        $allBundles = $this->kernel->getBundles();
+        foreach ($allBundles as $bundle) {
             // only include shopware bundles
             if (!$bundle instanceof Bundle) {
-                continue;
-            }
-            // dont include deactivated plugins
-            if ($bundle instanceof Plugin && !$bundle->isActive()) {
                 continue;
             }
             $bundleName = $bundle->getName();

--- a/src/Core/Framework/Bundle.php
+++ b/src/Core/Framework/Bundle.php
@@ -136,6 +136,11 @@ abstract class Bundle extends SymfonyBundle
         $container->setParameter('migration.directories', $directories);
     }
 
+    public function getIdentifier(): string
+    {
+        return get_class($this);
+    }
+
     protected function registerEvents(ContainerBuilder $container): void
     {
         $definition = $container->getDefinition(BusinessEventRegistry::class);

--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -7,8 +7,8 @@ use Shopware\Core\Framework\Plugin\Context\DeactivateContext;
 use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 use Shopware\Core\Framework\Plugin\Dependency\PluginDependencyBundleDescriptor;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
 abstract class Plugin extends Bundle
 {
@@ -83,5 +83,13 @@ abstract class Plugin extends Bundle
     public function getResolvedDependency(string $name): ?PluginDependencyBundleDescriptor
     {
         return isset($this->resolvedDependencies[$name]) ? $this->resolvedDependencies[$name] : null;
+    }
+
+    public function loadSharedBundle(string $sharedBundleName)
+    {
+        $bundlePath = sprintf('%1$s/SharedBundles/%2$s', $this->getPath(), $sharedBundleName);
+        $bundleDefinitionCreator = require $bundlePath . '/shared_bundle.php';
+
+        return $bundleDefinitionCreator($bundlePath);
     }
 }

--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -70,6 +70,11 @@ abstract class Plugin extends Bundle
         parent::configureRoutes($routes, $environment);
     }
 
+    public function getSubBundles(): array
+    {
+        return [];
+    }
+
     public function getDependencyBundleDescriptors(): array
     {
         return [];

--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -8,6 +8,7 @@ use Shopware\Core\Framework\Plugin\Context\InstallContext;
 use Shopware\Core\Framework\Plugin\Context\UninstallContext;
 use Shopware\Core\Framework\Plugin\Context\UpdateContext;
 use Symfony\Component\Routing\RouteCollectionBuilder;
+use Shopware\Core\Framework\Plugin\Dependency\PluginDependencyBundleDescriptor;
 
 abstract class Plugin extends Bundle
 {
@@ -16,13 +17,18 @@ abstract class Plugin extends Bundle
      */
     private $active;
 
+    /**
+     * @var array
+     */
+    private $resolvedDependencies = [];
+
     final public function __construct(bool $active = true, ?string $path = null)
     {
         $this->active = $active;
         $this->path = $path;
     }
 
-    final public function isActive(): bool
+    public function isActive(): bool
     {
         return $this->active;
     }
@@ -62,5 +68,20 @@ abstract class Plugin extends Bundle
         }
 
         parent::configureRoutes($routes, $environment);
+    }
+
+    public function getDependencyBundleDescriptors(): array
+    {
+        return [];
+    }
+
+    public function dependencyResolved(Plugin\Dependency\PluginDependencyBundleDescriptor $dependencyBundleDescriptor)
+    {
+        $this->resolvedDependencies[$dependencyBundleDescriptor->getName()] = $dependencyBundleDescriptor;
+    }
+
+    public function getResolvedDependency(string $name): ?PluginDependencyBundleDescriptor
+    {
+        return isset($this->resolvedDependencies[$name]) ? $this->resolvedDependencies[$name] : null;
     }
 }

--- a/src/Core/Framework/Plugin.php
+++ b/src/Core/Framework/Plugin.php
@@ -28,9 +28,9 @@ abstract class Plugin extends Bundle
         $this->path = $path;
     }
 
-    public function isActive(): bool
+    final public function isActive(): bool
     {
-        return $this->active;
+        return $this->active && $this->canBoot();
     }
 
     public function install(InstallContext $context): void
@@ -91,5 +91,10 @@ abstract class Plugin extends Bundle
         $bundleDefinitionCreator = require $bundlePath . '/shared_bundle.php';
 
         return $bundleDefinitionCreator($bundlePath);
+    }
+
+    protected function canBoot(): bool
+    {
+        return true;
     }
 }

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundle.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundle.php
@@ -2,22 +2,31 @@
 
 namespace Shopware\Core\Framework\Plugin\Dependency;
 
-use Shopware\Core\Kernel;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Symfony\Component\Routing\RouteCollectionBuilder;
+use Shopware\Core\Framework\Bundle;
 
 class PluginDependencyBundle extends Bundle
 {
-    public function configureRoutes(RouteCollectionBuilder $routes, string $environment): void
-    {
-        $fileSystem = new Filesystem();
-        $confDir = $this->getPath() . '/Resources';
+    /**
+     * @var string
+     */
+    private $version;
 
-        if ($fileSystem->exists($confDir)) {
-            $routes->import($confDir . '/{routes}/*' . Kernel::CONFIG_EXTS, '/', 'glob');
-            $routes->import($confDir . '/{routes}/' . $environment . '/**/*' . Kernel::CONFIG_EXTS, '/', 'glob');
-            $routes->import($confDir . '/{routes}' . Kernel::CONFIG_EXTS, '/', 'glob');
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function setVersion(string $version): void
+    {
+        $this->version = $version;
+    }
+
+    public function getIdentifier(): string
+    {
+        if (!$this->getVersion()) {
+            return parent::getIdentifier();
         }
+
+        return parent::getIdentifier() . ':' . $this->getVersion();
     }
 }

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundle.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundle.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Dependency;
+
+use Shopware\Core\Kernel;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\Routing\RouteCollectionBuilder;
+
+class PluginDependencyBundle extends Bundle
+{
+    public function configureRoutes(RouteCollectionBuilder $routes, string $environment): void
+    {
+        $fileSystem = new Filesystem();
+        $confDir = $this->getPath() . '/Resources';
+
+        if ($fileSystem->exists($confDir)) {
+            $routes->import($confDir . '/{routes}/*' . Kernel::CONFIG_EXTS, '/', 'glob');
+            $routes->import($confDir . '/{routes}/' . $environment . '/**/*' . Kernel::CONFIG_EXTS, '/', 'glob');
+            $routes->import($confDir . '/{routes}' . Kernel::CONFIG_EXTS, '/', 'glob');
+        }
+    }
+}

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundle.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundle.php
@@ -29,4 +29,9 @@ class PluginDependencyBundle extends Bundle
 
         return parent::getIdentifier() . ':' . $this->getVersion();
     }
+
+    public function setPath($path): void
+    {
+        $this->path = $path;
+    }
 }

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
@@ -2,8 +2,6 @@
 
 namespace Shopware\Core\Framework\Plugin\Dependency;
 
-use Symfony\Component\HttpKernel\Bundle\Bundle;
-
 /**
  * A description of a versioned bundle which one is required as a dependency by one or more plugins.
  *
@@ -32,7 +30,7 @@ class PluginDependencyBundleDescriptor
     private $bundleCreator;
 
     /**
-     * @var Bundle|null
+     * @var PluginDependencyBundle|null
      */
     private $bundle;
 
@@ -57,7 +55,7 @@ class PluginDependencyBundleDescriptor
         return $this->version;
     }
 
-    public function getBundle(): Bundle
+    public function getBundle(): PluginDependencyBundle
     {
         if (!$this->bundle) {
             $this->bundle = ($this->bundleCreator)();

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Dependency;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * A description of a versioned bundle which one is required as a dependency by one or more plugins.
+ *
+ * This class allows the Shopware kernel to coordinate loading of shared, versioned plugin dependency bundles by first
+ * resolving which version of the plugin dependency to give preference to (which should always be the one with the
+ * highest version number), and only then asking the plugin to register the dependency bundle's namespace and actually
+ * constructing the bundle class by calling the passed $bundleCreator closure. This layer of indirection is required to
+ * ensure that the correct versions of the bundle's namespaces are registered, resulting in the correct version of the
+ * bundle's classes being loaded - because once PHP has loaded a class, the class cannot be redefined.
+ */
+class PluginDependencyBundleDescriptor
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $version;
+
+    /**
+     * @var callable
+     */
+    private $bundleCreator;
+
+    /**
+     * @var Bundle|null
+     */
+    private $bundle;
+
+    /**
+     * @param callable $bundleCreator A closure which registers the bundle's namespace if required and returns an
+     *                                instance of the bundle
+     */
+    public function __construct(string $name, string $version, callable $bundleCreator)
+    {
+        $this->name = $name;
+        $this->version = $version;
+        $this->bundleCreator = $bundleCreator;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    public function getBundle(): Bundle
+    {
+        if (!$this->bundle) {
+            $this->bundle = ($this->bundleCreator)();
+        }
+
+        return $this->bundle;
+    }
+}

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
@@ -2,6 +2,8 @@
 
 namespace Shopware\Core\Framework\Plugin\Dependency;
 
+use Composer\Autoload\ClassLoader;
+
 /**
  * A description of a versioned bundle which one is required as a dependency by one or more plugins.
  *
@@ -66,10 +68,10 @@ class PluginDependencyBundleDescriptor
         return $this->path;
     }
 
-    public function getBundle(): PluginDependencyBundle
+    public function getBundle(ClassLoader $classLoader): PluginDependencyBundle
     {
         if (!$this->bundle) {
-            $this->bundle = ($this->bundleCreator)();
+            $this->bundle = ($this->bundleCreator)($classLoader);
         }
 
         return $this->bundle;

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleDescriptor.php
@@ -25,6 +25,11 @@ class PluginDependencyBundleDescriptor
     private $version;
 
     /**
+     * @var string
+     */
+    private $path;
+
+    /**
      * @var callable
      */
     private $bundleCreator;
@@ -38,10 +43,11 @@ class PluginDependencyBundleDescriptor
      * @param callable $bundleCreator A closure which registers the bundle's namespace if required and returns an
      *                                instance of the bundle
      */
-    public function __construct(string $name, string $version, callable $bundleCreator)
+    public function __construct(string $name, string $version, string $path, callable $bundleCreator)
     {
         $this->name = $name;
         $this->version = $version;
+        $this->path = $path;
         $this->bundleCreator = $bundleCreator;
     }
 
@@ -53,6 +59,11 @@ class PluginDependencyBundleDescriptor
     public function getVersion(): string
     {
         return $this->version;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
     }
 
     public function getBundle(): PluginDependencyBundle

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace Shopware\Core\Framework\Plugin\Dependency;
+
+use Shopware\Core\Framework\Plugin;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+/**
+ * Models the resolution algorithm for plugin dependency bundles. The algorithm is straight-forward:
+ *
+ * 1. Start with a list of all known plugins (active or inactive, installed or uninstalled).
+ * 2. For each plugin, ask the plugin to provide descriptors for its dependency bundles.
+ * 3. For each of these descriptors, if a dependency bundle with the same name is already known, keep only the one with
+ *    the highest version number.
+ * 4. This results in a list of resolved plugin dependency descriptors, i.e. a list containing at most one descriptor
+ *    for each dependency bundle name. Ask all of them to register their namespaces and return the resulting Bundles.
+ */
+class PluginDependencyBundleResolver
+{
+    /**
+     * @var Plugin[]
+     */
+    private $plugins;
+
+    /**
+     * @var PluginDependencyBundleDescriptor[]
+     */
+    private $resolvedDependencyDescriptors = [];
+
+    /**
+     * @var array
+     */
+    private $pluginsDependingOnDependencyBundles = [];
+
+    /**
+     * @var Bundle[]|null
+     */
+    private $resolvedBundles = null;
+
+    /**
+     * @param Plugin[] $plugins
+     */
+    public function __construct(array $plugins)
+    {
+        $this->plugins = $plugins;
+    }
+
+    /**
+     * @return Bundle[]
+     */
+    public function getResolvedBundles(): array
+    {
+        if ($this->resolvedBundles !== null) {
+            return $this->resolvedBundles;
+        }
+
+        $this->resolvedBundles = $this->resolveBundles();
+
+        return $this->resolvedBundles;
+    }
+
+    private function resolveBundles(): array
+    {
+        $this->resolvedDependencyDescriptors = [];
+
+        /* @var Plugin $activePlugin */
+        foreach ($this->plugins as $plugin) {
+            $dependencyDescriptors = $plugin->getDependencyBundleDescriptors();
+            /** @var PluginDependencyBundleDescriptor $dependencyDescriptor */
+            foreach ($dependencyDescriptors as $dependencyDescriptor) {
+                $this->registerDependencyDescriptor($dependencyDescriptor, $plugin);
+            }
+        }
+
+        $resolvedBundles = [];
+        foreach ($this->resolvedDependencyDescriptors as $dependencyDescriptor) {
+            $dependencyBundle = $dependencyDescriptor->getBundle();
+            /** @var Plugin $plugin */
+            foreach ($this->pluginsDependingOnDependencyBundles[$dependencyDescriptor->getName()] as $plugin) {
+                $plugin->dependencyResolved($dependencyDescriptor);
+            }
+            $resolvedBundles[] = $dependencyBundle;
+        }
+
+        return $resolvedBundles;
+    }
+
+    private function registerDependencyDescriptor(PluginDependencyBundleDescriptor $dependencyDescriptor, Plugin $plugin)
+    {
+        $bundleName = $dependencyDescriptor->getName();
+
+        // Dependency bundle is registered for the first time.
+        if (!isset($this->resolvedDependencyDescriptors[$bundleName])) {
+            $this->resolvedDependencyDescriptors[$bundleName] = $dependencyDescriptor;
+            $this->pluginsDependingOnDependencyBundles[$bundleName] = [$plugin];
+
+            return;
+        }
+
+        // When multiple dependency bundles of the same name are registered, resolve the conflict by using the latest
+        // version.
+        $existingDependencyDescriptor = $this->resolvedDependencyDescriptors[$bundleName];
+        if (version_compare($dependencyDescriptor->getVersion(), $existingDependencyDescriptor->getVersion(), '>')) {
+            $this->resolvedDependencyDescriptors[$bundleName] = $dependencyDescriptor;
+        }
+        $this->pluginsDependingOnDependencyBundles[$bundleName][] = $plugin;
+    }
+}

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
@@ -3,7 +3,6 @@
 namespace Shopware\Core\Framework\Plugin\Dependency;
 
 use Shopware\Core\Framework\Plugin;
-use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
  * Models the resolution algorithm for plugin dependency bundles. The algorithm is straight-forward:
@@ -33,7 +32,7 @@ class PluginDependencyBundleResolver
     private $pluginsDependingOnDependencyBundles = [];
 
     /**
-     * @var Bundle[]|null
+     * @var PluginDependencyBundle[]|null
      */
     private $resolvedBundles = null;
 
@@ -46,7 +45,7 @@ class PluginDependencyBundleResolver
     }
 
     /**
-     * @return Bundle[]
+     * @return PluginDependencyBundle[]
      */
     public function getResolvedBundles(): array
     {
@@ -61,8 +60,6 @@ class PluginDependencyBundleResolver
 
     private function resolveBundles(): array
     {
-        $this->resolvedDependencyDescriptors = [];
-
         /* @var Plugin $activePlugin */
         foreach ($this->plugins as $plugin) {
             $dependencyDescriptors = $plugin->getDependencyBundleDescriptors();
@@ -75,6 +72,7 @@ class PluginDependencyBundleResolver
         $resolvedBundles = [];
         foreach ($this->resolvedDependencyDescriptors as $dependencyDescriptor) {
             $dependencyBundle = $dependencyDescriptor->getBundle();
+            $dependencyBundle->setVersion($dependencyDescriptor->getVersion());
             /** @var Plugin $plugin */
             foreach ($this->pluginsDependingOnDependencyBundles[$dependencyDescriptor->getName()] as $plugin) {
                 $plugin->dependencyResolved($dependencyDescriptor);

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Plugin\Dependency;
 
+use Composer\Autoload\ClassLoader;
 use Shopware\Core\Framework\Plugin;
 
 /**
@@ -22,6 +23,11 @@ class PluginDependencyBundleResolver
     private $plugins;
 
     /**
+     * @var ClassLoader
+     */
+    private $classLoader;
+
+    /**
      * @var PluginDependencyBundleDescriptor[]
      */
     private $resolvedDependencyDescriptors = [];
@@ -39,9 +45,10 @@ class PluginDependencyBundleResolver
     /**
      * @param Plugin[] $plugins
      */
-    public function __construct(array $plugins)
+    public function __construct(array $plugins, ClassLoader $classLoader)
     {
         $this->plugins = $plugins;
+        $this->classLoader = $classLoader;
     }
 
     /**
@@ -71,7 +78,7 @@ class PluginDependencyBundleResolver
 
         $resolvedBundles = [];
         foreach ($this->resolvedDependencyDescriptors as $dependencyDescriptor) {
-            $dependencyBundle = $dependencyDescriptor->getBundle();
+            $dependencyBundle = $dependencyDescriptor->getBundle($this->classLoader);
             $dependencyBundle->setVersion($dependencyDescriptor->getVersion());
             $dependencyBundle->setPath($dependencyDescriptor->getPath());
             /** @var Plugin $plugin */

--- a/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
+++ b/src/Core/Framework/Plugin/Dependency/PluginDependencyBundleResolver.php
@@ -73,6 +73,7 @@ class PluginDependencyBundleResolver
         foreach ($this->resolvedDependencyDescriptors as $dependencyDescriptor) {
             $dependencyBundle = $dependencyDescriptor->getBundle();
             $dependencyBundle->setVersion($dependencyDescriptor->getVersion());
+            $dependencyBundle->setPath($dependencyDescriptor->getPath());
             /** @var Plugin $plugin */
             foreach ($this->pluginsDependingOnDependencyBundles[$dependencyDescriptor->getName()] as $plugin) {
                 $plugin->dependencyResolved($dependencyDescriptor);

--- a/src/Core/Framework/Plugin/KernelPluginCollection.php
+++ b/src/Core/Framework/Plugin/KernelPluginCollection.php
@@ -2,6 +2,7 @@
 
 namespace Shopware\Core\Framework\Plugin;
 
+use Composer\Autoload\ClassLoader;
 use Shopware\Core\Framework\Plugin;
 use Shopware\Core\Framework\Plugin\Dependency\PluginDependencyBundleResolver;
 
@@ -87,11 +88,11 @@ class KernelPluginCollection
         });
     }
 
-    public function getPluginDependencyBundles(): array
+    public function getPluginDependencyBundles(ClassLoader $classLoader): array
     {
         if ($this->pluginDependencyBundleResolver === null) {
             $this->seal();
-            $this->pluginDependencyBundleResolver = new PluginDependencyBundleResolver(array_values($this->plugins));
+            $this->pluginDependencyBundleResolver = new PluginDependencyBundleResolver(array_values($this->plugins), $classLoader);
         }
 
         return $this->pluginDependencyBundleResolver->getResolvedBundles();

--- a/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
+++ b/src/Core/Framework/Test/TestCaseBase/KernelLifecycleManager.php
@@ -4,23 +4,23 @@ namespace Shopware\Core\Framework\Test\TestCaseBase;
 
 use Composer\Autoload\ClassLoader;
 use Shopware\Core\Framework\Test\Filesystem\Adapter\MemoryAdapterFactory;
+use Shopware\Core\Kernel;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\DependencyInjection\ResettableContainerInterface;
-use Symfony\Component\HttpKernel\KernelInterface;
 
 class KernelLifecycleManager
 {
     protected static $class;
 
     /**
-     * @var KernelInterface|null
+     * @var Kernel|null
      */
     protected static $kernel;
 
     /**
      * Get the currently active kernel
      */
-    public static function getKernel(): KernelInterface
+    public static function getKernel(): Kernel
     {
         if (static::$kernel) {
             return static::$kernel;
@@ -32,7 +32,7 @@ class KernelLifecycleManager
     /**
      * Create a web client with the default kernel and disabled reboots
      */
-    public static function createClient(KernelInterface $kernel, bool $enableReboot = false): Client
+    public static function createClient(Kernel $kernel, bool $enableReboot = false): Client
     {
         /** @var Client $apiClient */
         $apiClient = $kernel->getContainer()->get('test.client');
@@ -49,11 +49,14 @@ class KernelLifecycleManager
     /**
      * Boots the Kernel for this test.
      */
-    public static function bootKernel(): KernelInterface
+    public static function bootKernel($plugins = []): Kernel
     {
         static::ensureKernelShutdown();
 
         static::$kernel = static::createKernel();
+        foreach ($plugins as $plugin) {
+            Kernel::getPlugins()->add($plugin);
+        }
         static::$kernel->boot();
         MemoryAdapterFactory::resetInstances();
 
@@ -77,7 +80,7 @@ class KernelLifecycleManager
         return $class;
     }
 
-    private static function createKernel(): KernelInterface
+    private static function createKernel(): Kernel
     {
         if (static::$class === null) {
             static::$class = static::getKernelClass();

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -71,8 +71,8 @@ class Kernel extends HttpKernel
             }
         }
 
-        yield from self::$plugins->getActives();
         yield from self::$plugins->getPluginDependencyBundles(self::$classLoader);
+        yield from self::$plugins->getActives();
     }
 
     public function boot($withPlugins = true): void

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -30,6 +30,11 @@ class Kernel extends HttpKernel
     public const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
     /**
+     * @var ClassLoader
+     */
+    protected static $classLoader;
+
+    /**
      * @var Connection|null
      */
     protected static $connection;
@@ -40,11 +45,6 @@ class Kernel extends HttpKernel
     protected static $plugins;
 
     /**
-     * @var ClassLoader
-     */
-    protected $classLoader;
-
-    /**
      * {@inheritdoc}
      */
     public function __construct(string $environment, bool $debug, ClassLoader $classLoader)
@@ -52,6 +52,7 @@ class Kernel extends HttpKernel
         parent::__construct($environment, $debug);
 
         self::$plugins = new KernelPluginCollection();
+        self::$classLoader = $classLoader;
         self::$connection = null;
 
         $this->classLoader = $classLoader;
@@ -105,6 +106,9 @@ class Kernel extends HttpKernel
 
         // init container
         $this->initializeContainer();
+
+        // expose the Kernel's class loader in the container
+        $this->container->set('class_loader', self::$classLoader);
 
         /** @var Bundle|ContainerAwareTrait $bundle */
         foreach ($this->getBundles() as $bundle) {

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -72,7 +72,7 @@ class Kernel extends HttpKernel
         }
 
         yield from self::$plugins->getActives();
-        yield from self::$plugins->getPluginDependencyBundles();
+        yield from self::$plugins->getPluginDependencyBundles(self::$classLoader);
     }
 
     public function boot($withPlugins = true): void

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -30,11 +30,6 @@ class Kernel extends HttpKernel
     public const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
     /**
-     * @var ClassLoader
-     */
-    protected static $classLoader;
-
-    /**
      * @var Connection|null
      */
     protected static $connection;
@@ -45,6 +40,11 @@ class Kernel extends HttpKernel
     protected static $plugins;
 
     /**
+     * @var ClassLoader
+     */
+    protected $classLoader;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct(string $environment, bool $debug, ClassLoader $classLoader)
@@ -52,7 +52,6 @@ class Kernel extends HttpKernel
         parent::__construct($environment, $debug);
 
         self::$plugins = new KernelPluginCollection();
-        self::$classLoader = $classLoader;
         self::$connection = null;
 
         $this->classLoader = $classLoader;
@@ -71,7 +70,7 @@ class Kernel extends HttpKernel
             }
         }
 
-        yield from self::$plugins->getPluginDependencyBundles(self::$classLoader);
+        yield from self::$plugins->getPluginDependencyBundles($this->classLoader);
 
         foreach (self::$plugins->getActives() as $plugin) {
             yield $plugin;
@@ -112,7 +111,7 @@ class Kernel extends HttpKernel
         $this->initializeContainer();
 
         // expose the Kernel's class loader in the container
-        $this->container->set('class_loader', self::$classLoader);
+        $this->container->set('class_loader', $this->classLoader);
 
         /** @var Bundle|ContainerAwareTrait $bundle */
         foreach ($this->getBundles() as $bundle) {

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -72,7 +72,11 @@ class Kernel extends HttpKernel
         }
 
         yield from self::$plugins->getPluginDependencyBundles(self::$classLoader);
-        yield from self::$plugins->getActives();
+
+        foreach (self::$plugins->getActives() as $plugin) {
+            yield $plugin;
+            yield from $plugin->getSubBundles();
+        }
     }
 
     public function boot($withPlugins = true): void


### PR DESCRIPTION
- [ ] Depends on https://github.com/VIISON/shopware-development/pull/3

### TODO

- [x] Administration extensions
- [x] Assetic / Assets process
- [x] Template Extensions?
- [x] Shared loader
- [x] Use shared loader to load shared bundles
- [x] getContainerClass alle Bundles mit hashen
- [x] Simplify `PluginBundleDescriptor` usage
- [x] `isActive()` -> template method to disable plugin during boot
- [x] Non-shared sub-bundles?
- [ ] Rebase again
- [ ] Rename / Refactor
- [ ] Get Feedback
- [ ] Docs
- [ ] Tests