### PR TITLE
Add CriteriaFactory to application container

### DIFF
--- a/src/Administration/Resources/administration/src/core/common.js
+++ b/src/Administration/Resources/administration/src/core/common.js
@@ -7,6 +7,7 @@ const Bottle = require('bottlejs');
 
 const ModuleFactory = require('src/core/factory/module.factory').default;
 const ComponentFactory = require('src/core/factory/component.factory').default;
+const CriteriaFactory = require('src/core/factory/criteria.factory').default;
 const TemplateFactory = require('src/core/factory/template.factory').default;
 const EntityFactory = require('src/core/factory/entity.factory').default;
 const StateFactory = require('src/core/factory/state.factory').default;
@@ -32,6 +33,9 @@ const application = new ApplicationBootstrapper(container);
 application
     .addFactory('component', () => {
         return ComponentFactory;
+    })
+    .addFactory('criteria', () => {
+        return CriteriaFactory;
     })
     .addFactory('template', () => {
         return TemplateFactory;


### PR DESCRIPTION
### 1. Why is this change necessary?

The `CriteriaFactory` is missing from the factory container.

### 2. What does this change do, exactly?

Adds the `CriteriaFactory` to the factory container so it can be used using
```
const CriteriaFactory = Shopware.Application.getContainer('factory').criteria;
```
instead of 
```
import CriteriaFactory from 'src/core/factory/criteria.factory';
```

### 3. Describe each step to reproduce the issue or behaviour.


### 4. Please link to the relevant issues (if any).


### 5. Which documentation changes (if any) need to be made because of this PR?


### 6. Checklist

- [ ] I have written tests and verified that they fail without my change
- [ ] I have squashed any insignificant commits
- [ ] This change has comments for package types, values, functions, and non-obvious lines of code
- [ ] I have read the contribution requirements and fulfil them.
