### PR TITLE
Fix building of super call cain

### DIFF
--- a/src/Administration/Resources/app/administration/src/core/factory/component.factory.js
+++ b/src/Administration/Resources/app/administration/src/core/factory/component.factory.js
@@ -482,15 +482,17 @@ function findMethodInChain(extension, methodName, methodsOrComputed) {
         return resolveGetterSetterChain(extension, splitPath, methodsOrComputed);
     }
 
-    if (!extension[methodsOrComputed]) {
-        return findMethodInChain(extension.extends, methodName, methodsOrComputed);
+    if (extension.extends) {
+        if (!extension[methodsOrComputed]) {
+            return findMethodInChain(extension.extends, methodName, methodsOrComputed);
+        }
+
+        if (!extension[methodsOrComputed][methodName]) {
+            return findMethodInChain(extension.extends, methodName, methodsOrComputed);
+        }
     }
 
-    if (!extension[methodsOrComputed][methodName]) {
-        return findMethodInChain(extension.extends, methodName, methodsOrComputed);
-    }
-
-    return extension[methodsOrComputed][methodName];
+    return extension[methodsOrComputed] ? extension[methodsOrComputed][methodName] : null;
 }
 
 /**

--- a/src/Administration/Resources/app/administration/test/factory/component.factory.spec.js
+++ b/src/Administration/Resources/app/administration/test/factory/component.factory.spec.js
@@ -846,4 +846,88 @@ describe('core/factory/component.factory.js', () => {
         expect(typeof component.vm.$super).toBe('function');
         expect(component.vm.$super('fooBar')).toBe('fooBar');
     });
+
+    it(
+        // eslint-disable-next-line max-len
+        'correctly builds the super call stack if root component of the inheritance chain does not implement an overridden method',
+        () => {
+            ComponentFactory.register('grandparent-component', {
+                template: '<div>This is a test template.</div>'
+            });
+            ComponentFactory.extend('parent-component', 'grandparent-component', {
+                methods: {
+                    fooBar() {
+                        return 'called';
+                    }
+                }
+            });
+            ComponentFactory.extend('child-component', 'parent-component', {
+                methods: {
+                    fooBar() {
+                        return this.$super('fooBar');
+                    }
+                }
+            });
+
+            const childComponent = shallowMount(ComponentFactory.build('child-component'));
+
+            expect(childComponent.vm.fooBar()).toBe('called');
+        }
+    );
+
+    it(
+        // eslint-disable-next-line max-len
+        'correctly builds the super call stack if one component of the inheritance chain does not implement an overridden method',
+        () => {
+            ComponentFactory.register('grandparent-component', {
+                template: '<div>This is a test template.</div>',
+                methods: {
+                    fooBar() {
+                        return 'called';
+                    }
+                }
+            });
+            ComponentFactory.extend('parent-component', 'grandparent-component', {});
+            ComponentFactory.extend('child-component', 'parent-component', {
+                methods: {
+                    fooBar() {
+                        return this.$super('fooBar');
+                    }
+                }
+            });
+
+            const childComponent = shallowMount(ComponentFactory.build('child-component'));
+
+            expect(childComponent.vm.fooBar()).toBe('called');
+        }
+    );
+
+    it(
+        // eslint-disable-next-line max-len
+        'correctly builds the super call stack if components in the beginning of the inheritance chain do not implement an overridden method',
+        () => {
+            ComponentFactory.register('great-grandparent-component', {
+                template: '<div>This is a test template.</div>'
+            });
+            ComponentFactory.extend('grandparent-component', 'great-grandparent-component', {});
+            ComponentFactory.extend('parent-component', 'grandparent-component', {
+                methods: {
+                    fooBar() {
+                        return 'called';
+                    }
+                }
+            });
+            ComponentFactory.extend('child-component', 'parent-component', {
+                methods: {
+                    fooBar() {
+                        return this.$super('fooBar');
+                    }
+                }
+            });
+
+            const childComponent = shallowMount(ComponentFactory.build('child-component'));
+
+            expect(childComponent.vm.fooBar()).toBe('called');
+        }
+    );
 });


### PR DESCRIPTION
<!--
Thank you for contributing to Shopware! Please fill out this description template to help us to process your pull request.

Please make sure to fulfil our contribution guideline (https://docs.shopware.com/en/shopware-platform-dev-en/community/contribution-guideline?category=shopware-platform-dev-en/community).

Do your changes need to be mentioned in the documentation?
Add notes on your change right now in the documentation files in /src/Docs/Resources and add them to the pull request as well. 
-->

### 1. Why is this change necessary?
There is a special case where the call of `ComponentFactory.extend` would lead to an error:

![image](https://user-images.githubusercontent.com/6232639/72070146-18057100-32e9-11ea-84e1-1184bd333012.png)

This when the inheritance chain is like the following:

- `Child` extends `Parent` extends `Grandparent`.
- Child overrides method `foo` from component `Parent`, but `foo` does not exist in `Grandparent`

### 2. What does this change do, exactly?
It hopefully fixes the error. Would be nice if someone would double check the fix.

### 3. Describe each step to reproduce the issue or behaviour.
Please see the unit tests.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [x] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
