### PR TITLE
Allow sw-inheritance field in API request header

### DIFF
--- a/CHANGELOG-6.2.md
+++ b/CHANGELOG-6.2.md
@@ -481,7 +481,9 @@ To get the diff between two versions, go to https://github.com/shopware/platform
     * Deprecated `sort` parameter for product listing, search and suggest gateway, use `order` instead
     * Deprecated `\Shopware\Core\Framework\DataAbstractionLayer\Search\RequestCriteriaBuilder::getAllowedLimits`
     * Deprecated `shopware.api.allowed_limits` configuration
-    * Added `definition` parameter in `\Shopware\Elasticsearch\Framework\ElasticsearchHelper::addTerm` 
+    * Added `definition` parameter in `\Shopware\Elasticsearch\Framework\ElasticsearchHelper::addTerm`
+    * Allow `sw-inheritance` field in API request header.
+    
 * Storefront
     * Deprecated `$connection->executeQuery()` for write operations
     * Added `\Shopware\Core\Framework\Api\Controller\CaptchaController` which provides a list of all available captchas to the administration

--- a/src/Core/Framework/Api/EventListener/CorsListener.php
+++ b/src/Core/Framework/Api/EventListener/CorsListener.php
@@ -46,6 +46,7 @@ class CorsListener implements EventSubscriberInterface
             PlatformRequest::HEADER_ACCESS_KEY,
             PlatformRequest::HEADER_LANGUAGE_ID,
             PlatformRequest::HEADER_VERSION_ID,
+            PlatformRequest::HEADER_INHERITANCE,
         ];
 
         $response = $event->getResponse();


### PR DESCRIPTION
### 1. Why is this change necessary?

When using the sw-inheritance header field in API requests an error is thrown, because the inheritance field is not allowed:

> Access to XMLHttpRequest at 'http://localhost/shopware/api/v1/search/product' from origin 'http://localhost:8080' has been blocked by CORS policy: Request header field sw-inheritance is not allowed by Access-Control-Allow-Headers in preflight response.



### 2. What does this change do, exactly?

This PR fixes this by allowing the sw-inheritance field in requests headers.

### 3. Describe each step to reproduce the issue or behaviour.

The inheritance header is currently used in the `sw-cms-el-config-product-box` component: https://github.com/shopware/platform/blob/5c989b45b64c23d368f769bab906f4d26541e2d5/src/Administration/Resources/app/administration/src/module/sw-cms/elements/product-box/config/index.js#L21-L26
When using it and searching for products, the error is returned from the server.

### 4. Please link to the relevant issues (if any).


### 5. Checklist

- [ ] I have written tests and verified that they fail without my change
- [x] I have squashed any insignificant commits
- [x] I have written or adjusted the documentation according to my changes
- [x] This change has comments for package types, values, functions, and non-obvious lines of code
- [x] I have read the contribution requirements and fulfil them.
